### PR TITLE
Simplify markdown output

### DIFF
--- a/lib/taser-markdown-report.js
+++ b/lib/taser-markdown-report.js
@@ -18,9 +18,7 @@ class TaserMarkdownReport {
             throw new Error('Expected taser reports to be an Array');
         }
 
-        let markdownReport = [
-            reportHeader()
-        ];
+        let markdownReport = [];
 
         for( let i = 0; i < taserReports.length; i++ ) {
             let problem = taserReports[i].problem;
@@ -47,27 +45,18 @@ class TaserMarkdownReport {
 
 module.exports = TaserMarkdownReport;
 
-function reportHeader() {
-    return [
-        '# :zap: Taser Report :zap:',
-        ''
-    ];
-}
-
 function reportError(problem) {
     return [
-        `###: :x: Error testing ${problem}`,
-        '#### Please review the problem and submit a new pull request',
-        '(hint: your function might be returning `null` or `undefined`'
+        `### 500 (Internal Taser Error)`,
+        `There was a fatal error testing ${problem} :sob:`,
+        ''
     ];
 }
 
 function problemReportHeader(problem) {
     return [
-        '',
-        '----',
-        '',
-        `## Problem: ${problem}`
+        `## Problem: ${problem}`,
+        ''
     ];
 }
 
@@ -75,25 +64,17 @@ function problemReportBody(report) {
     return [
         testReportHeader(report),
         testReportErrors(report.errors),
-        testReportPassed(report.testResults.passed),
-        testReportFailed(report.testResults.failed)
+        testReportFailed(report.testResults.failed),
+        testReportPassed(report.testResults.passed)
     ];
 }
 
 function testReportHeader(report) {
-    let contextName = report.browser.name;
-    let numberOfErrors = report.errors.length;
     let numberOfPasses = report.testResults.passed.length;
     let numberOfFailures = report.testResults.failed.length;
 
     return [
-        `**Browser**: ${contextName}`,
-        '',
-        '| Type | Count |',
-        '| ---- | ----- |',
-        `| Errors | ${numberOfErrors} |`,
-        `| Failed | ${numberOfFailures} |`,
-        `| Passed | ${numberOfPasses} |`,
+        `> #### summary: ${numberOfPasses} / ${numberOfPasses + numberOfFailures}`,
         ''
     ];
 }
@@ -102,13 +83,16 @@ function testReportErrors(errors) {
     let content = [];
 
     if (errors.length) {
-        content.push('');
-        content.push('### Errors: ');
+        content.push('### Errors:');
         content.push('');
 
         for( let i = 0; i < errors.length; i++ ) {
-            content.push(`1. \`${errors[i]}\`  `);
+            content.push('```');
+            content.push(errors[i]);
+            content.push('```');
         }
+
+        content.push('');
     }
 
     return content;
@@ -118,16 +102,14 @@ function testReportPassed(passedTests) {
     let content = [];
 
     if (passedTests.length) {
-        content.push('');
-        content.push('### Passed: ');
-        content.push('');
-
         for( let i = 0; i < passedTests.length; i++ ) {
-            let testSuite = passedTests[i].suite.join(' ⟶ ');
+            let testSuite = passedTests[i].suite.join(' ');
             let testDescription = passedTests[i].description;
 
-            content.push(`#### :heavy_check_mark: ${i}. ${testSuite} ⟶ ${testDescription}  `);
+            content.push(`**:tada: ${testSuite} ${testDescription}**`);
         }
+
+        content.push('');
     }
 
     return content;
@@ -137,39 +119,26 @@ function testReportFailed(failedTests) {
     let content = [];
 
     if (failedTests.length) {
-        content.push('');
-        content.push('### Failed: ');
-        content.push('');
-
         for( let i = 0; i < failedTests.length; i++ ) {
-            let testSuite = failedTests[i].suite.join(' ⟶ ');
+            let testSuite = failedTests[i].suite.join(' ');
             let testDescription = failedTests[i].description;
 
-            content.push(`#### :heavy_multiplication_x: ${i}. ${testSuite} ⟶ testDescription  `);
-
-            if( failedTests[i].fn ) {
-                content.push('  * **Test:**');
-                content.push('  ```javascript');
-                content.push('');
-                content.push('')
-                content.push(`${failedTests[i].fn}`);
-                content.push('');
-                content.push('````  ');
-            }
+            content.push(`**:x: ${testSuite} ${testDescription}**`);
 
             for( let j = 0; j < failedTests[i].log.length; j++ ) {
                 let failedTestLog = failedTests[i].log[j];
 
-                content.push('  * **Log:**');
-                content.push('  ```shell');
-                content.push('');
-                content.push('');
+                content.push('```');
                 content.push(`${failedTestLog}`);
-                content.push('');
-                content.push('````  ');
+                content.push('```');
             }
 
-            content.push('---------  ');
+            if( failedTests[i].fn ) {
+                content.push('```js');
+                content.push(`${failedTests[i].fn}`);
+                content.push('```');
+            }
+
             content.push('');
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taser-markdown-report",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A taser reporter that formats its output in Github flavored markdown",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Comment space is precious, and a verbose comment can be hard to parse (and sometimes lead to errors reactorcore-labs/app.sweat-shop.taser#17). This PR simplifies the markdown output to get students the most important information up front.
### Before

![screen shot 2016-05-03 at 4 55 48 pm](https://cloud.githubusercontent.com/assets/6980359/15001890/37fcd49e-1150-11e6-9f48-795b53e72b0e.png)
### After

![screen shot 2016-05-03 at 4 56 53 pm](https://cloud.githubusercontent.com/assets/6980359/15001892/3def343c-1150-11e6-9ce5-d00a25aa1d3a.png)
